### PR TITLE
README.md: book location is rustcrypto.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Reference manual for the RustCrypto project, implemented as a MDBook \[WIP\].
 
-You can read the book at <https://RustCrypto.github.io/book/>.
+You can read the book at <https://rustcrypto.org/>.
 
 ## Contributing
 


### PR DESCRIPTION
I've configured GitHub Pages to publish underneath the <https://rustcrypto.org> domain.