### PR TITLE
remove the unused and deprecated `multilingual` field from `book.toml`

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["RustCrypto Organization"]
 language = "en"
-multilingual = false
 title = "The RustCrypto Book"
 description = "Reference manual for the RustCrypto project"
 


### PR DESCRIPTION
See https://github.com/szabgab/public-mdbooks/issues/10